### PR TITLE
[NO-JIRA] Pin Bundler Version for Compatibility with Ruby 2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7-alpine
 RUN apk add --no-cache git
 
 RUN set -x \
-  && gem install bundler keycutter
+  && gem install bundler:2.4.22 keycutter
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
- Running this action currently fails due to incompatibility between the latest bundler version and the version of ruby running.
- Copying across the [fix](https://github.com/jstastny/publish-gem-to-github/pull/14) implemented on the forked repo which pins the bundler version.
- We could look to bump the ruby version but I'm not sure I see the point for something as simple as this?