### PR TITLE
Use ruby 3 for docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.2-alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
When we try and build, we're getting this error the whole time: 

<img width="1084" alt="Screenshot 2024-02-29 at 09 20 01" src="https://github.com/thrivadev/publish-gem-to-github/assets/3011357/b0f38566-a9f0-4830-a16e-d376cb0a6339">

Link to build: https://github.com/thrivadev/thriva-rubocop/actions/runs/8083718354/job/22116683845

upgrading to use a 3.2 ruby docker image should fix this.
